### PR TITLE
Dynamic comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # github-pr-comment-buildkite-plugin
 buildkite plugin to post a comment in a PR
 
-## Example
-
+## Examples
+You can post basic string literal comments very easily:
 ```yml
 steps:
   plugins:
-    - telefonica/github-pr-comment#0.0.5:
+    - ssh://git@github.com/fanduel/github-pr-comment-buildkite-plugin.git#v1.0.0:
         comment: Some text
         pr: ${BUILDKITE_PULL_REQUEST} # Optional, PR Number to add the comment
         repo: ${BUILDKITE_PULL_REQUEST_REPO} # Optional, format git://github.com:user/repo.git)
 ```
 
-## Authentication
-The plugin needs an env var called [`GITHUB_TOKEN` with `repo` access](https://github.com/settings/tokens) to post comments
+By setting the `dynamic` property to `true`, we can pass the name of an environment variable whose value will be used for the comment body.
+```yml
+steps:
+  - label: Set some meta-data
+    command: buildkite-agent meta-data set username ${BUILDKITE_BUILD_CREATOR_EMAIL}
+    # The meta-data key "username" and its value get exported as METAENV_USERNAME via the metaenv plugin in the next step
+
+  - plugins:
+      - ssh://git@github.com/fanduel/metaenv-buildkite-plugin.git#v1.0.0
+      - ssh://git@github.com/fanduel/github-pr-comment-buildkite-plugin.git#v1.0.0:
+          comment: METAENV_USERNAME
+          dynamic: true
+```

--- a/hooks/command
+++ b/hooks/command
@@ -40,7 +40,13 @@ fi
 
 echo "Posting comment to PR $PR in ${GITHUB_USER}/${GITHUB_REPO}"  1>&2
 
-jq -n --arg msg "${BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT}" '{body: $msg}' | curl -sSg \
+if [[ $BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT == \$* ]]; then 
+    pr_comment_message = ${!BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT}
+else
+    pr_comment_message = ${BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT}
+fi
+
+jq -n --arg msg "${pr_comment_message}" '{body: $msg}' | curl -sSg \
     -u apikey:${GITHUB_TOKEN} \
     -H 'Accept: application/vnd.github.v3+json' \
     -H 'Content-Type: application/json' \

--- a/hooks/command
+++ b/hooks/command
@@ -40,10 +40,10 @@ fi
 
 echo "Posting comment to PR $PR in ${GITHUB_USER}/${GITHUB_REPO}"  1>&2
 
-if [[ $BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT == \$* ]]; then 
-    pr_comment_message = ${!BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT}
+if [[ $BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_DYNAMIC ]]; then 
+    pr_comment_message=${!BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT}
 else
-    pr_comment_message = ${BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT}
+    pr_comment_message=${BUILDKITE_PLUGIN_GITHUB_PR_COMMENT_COMMENT}
 fi
 
 jq -n --arg msg "${pr_comment_message}" '{body: $msg}' | curl -sSg \

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,9 @@ configuration:
       type: string
     commit:
       type: string
+    dynamic:
+      type: boolean
+      default: false
   required:
     - comment
   additionalProperties: false


### PR DESCRIPTION
- Adds a `dynamic` boolean parameter to control whether to use indirect expansion on the value passed in the `comment` field
- This allows you to pass the name of an environment variable whose value will then be used in the comment body of the GitHub comment
- By default preserves the behaviour of the original plugin